### PR TITLE
Feature/dev local

### DIFF
--- a/app/Console/Commands/MigrateAttachmentsData.php
+++ b/app/Console/Commands/MigrateAttachmentsData.php
@@ -54,24 +54,23 @@ class MigrateAttachmentsData extends Command
     {
         $this->info('Migrate Attachments Data...');
 
-        $this->warn('Migrating post attachment');
+        $this->warn('Migrating post attachments');
         $this->processAttachmentData('posts');
-        $this->info('Post attachment migrated');
+        $this->info('Post attachments migrated');
 
-        $this->warn('Migrating comment attachment');
+        $this->warn('Migrating comment attachments');
         $this->processAttachmentData('comments');
-        $this->info('Comment attachment migrated');
+        $this->info('Comment attachments migrated');
 
         $this->info('Data Migrated!');
     }
 
     protected function processAttachmentData(string $type)
     {
-        if ($type == 'posts')
-            $attachments = $this->getPostAttachmentData();
-        
-        if ($type == 'comments')
-            $attachments = $this->getCommentAttachmentData();
+        $attachments = array();
+
+        if ($type == 'posts') $attachments = $this->getPostAttachmentData();
+        if ($type == 'comments') $attachments = $this->getCommentAttachmentData();
         
         foreach ($attachments as $value)
         {

--- a/app/Console/Commands/MigrateAttachmentsData.php
+++ b/app/Console/Commands/MigrateAttachmentsData.php
@@ -2,10 +2,17 @@
 
 namespace App\Console\Commands;
 
+use App\Repositories\Application\PostAttachmentRepository;
+use App\Repositories\Application\CommentAttachmentRepository;
+use App\Repositories\Application\AttachmentRepository;
 use Illuminate\Console\Command;
 
 class MigrateAttachmentsData extends Command
 {
+    protected $repPostAttchment;
+    protected $repCommentAttchment;
+    protected $repAttchment;
+
     /**
      * The name and signature of the console command.
      *
@@ -25,9 +32,15 @@ class MigrateAttachmentsData extends Command
      *
      * @return void
      */
-    public function __construct()
+    public function __construct(PostAttachmentRepository $repPostAttchment,
+        CommentAttachmentRepository $repCommentAttchment,
+        AttachmentRepository $repAttchment)
     {
         parent::__construct();
+
+        $this->repPostAttchment = $repPostAttchment;
+        $this->repCommentAttchment = $repCommentAttchment;
+        $this->repAttchment = $repAttchment;
     }
 
     /**
@@ -45,10 +58,22 @@ class MigrateAttachmentsData extends Command
     protected function processPostAttachmentData()
     {
         $postAttachments = $this->getPostAttachmentData();
+        $commentAttachments = $this->getCommentAttachmentData();
+        $attachments = $this->getAttachmentData();
     }
 
     protected function getPostAttachmentData()
     {
-        
+        return $this->repPostAttchment->all();
+    }
+
+    protected function getCommentAttachmentData()
+    {
+        return $this->repCommentAttchment->all();
+    }
+
+    protected function getAttachmentData()
+    {
+        return $this->repAttchment->all();
     }
 }

--- a/app/Console/Commands/MigrateAttachmentsData.php
+++ b/app/Console/Commands/MigrateAttachmentsData.php
@@ -84,7 +84,7 @@ class MigrateAttachmentsData extends Command
     {
         return new Request([
             'attachmentable_type' => $type,
-            'attachmentable_id' => $value->id,
+            'attachmentable_id' => $type == 'posts' ? $value->post_id : $value->comment_id,
             'url' => $value->url
         ]);
     }

--- a/app/Console/Commands/MigrateAttachmentsData.php
+++ b/app/Console/Commands/MigrateAttachmentsData.php
@@ -38,5 +38,17 @@ class MigrateAttachmentsData extends Command
     public function handle()
     {
         $this->info('Migrating Attachments Data');
+
+        $this->processPostAttachmentData();
+    }
+
+    protected function processPostAttachmentData()
+    {
+        $postAttachments = $this->getPostAttachmentData();
+    }
+
+    protected function getPostAttachmentData()
+    {
+        
     }
 }

--- a/app/Console/Commands/MigrateAttachmentsData.php
+++ b/app/Console/Commands/MigrateAttachmentsData.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class MigrateAttachmentsData extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'migrate_attachments_data';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Migrate Attachments Data';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $this->info('Migrating Attachments Data');
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class PostController extends Controller
+{
+    public function index()
+    {
+        return view('index', [
+            'users' => \App\Models\User::all()
+        ]);
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -3,13 +3,25 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\User;
+use DB;
+use App\Repositories\Application\UserRepository;
 
 class PostController extends Controller
 {
+    protected $repUser;
+
+    public function __construct(UserRepository $repUser)
+    {
+        $this->repUser = $repUser;
+    }
+
     public function index()
     {
+        $users = $this->repUser->getUsersWithPosts();
+
         return view('index', [
-            'users' => \App\Models\User::all()
+            'users' => $users
         ]);
     }
 }

--- a/app/Models/Attachment.php
+++ b/app/Models/Attachment.php
@@ -14,4 +14,9 @@ class Attachment extends Model
         'attachmentable_id',
         'url',
     ];
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
 }

--- a/app/Models/Attachment.php
+++ b/app/Models/Attachment.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Attachment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'attachmentable_type',
+        'attachmentable_id',
+        'url',
+    ];
+}

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -26,6 +26,6 @@ class Comment extends Model
 
     public function comment_attachments()
     {
-        return $this->hasMany(CommentAttachment::class);
+        return $this->morphMany(Attachment::class, 'attachmentable');
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -2,8 +2,10 @@
 
 namespace App\Models;
 
+use DB;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+
 
 class Post extends Model
 {
@@ -33,5 +35,14 @@ class Post extends Model
     public function post_attachments()
     {
         return $this->morphMany(Attachment::class, 'attachmentable');
+    }
+
+    public function sumCommentsAttachmentCount()
+    {
+        return Comment::where('post_id', $this->attributes['id'])
+            ->sum(DB::raw("(select count(*) from attachments 
+                where attachmentable_type = 'comments' 
+                and attachmentable_id = comments.id)
+            "));
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -32,6 +32,6 @@ class Post extends Model
 
     public function post_attachments()
     {
-        return $this->hasMany(PostAttachment::class);
+        return $this->morphMany(Attachment::class, 'attachmentable');
     }
 }

--- a/app/Providers/PolymorphismProvider.php
+++ b/app/Providers/PolymorphismProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use App\Models\Post;
+use App\Models\Comment;
+
+class PolymorphismProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        Relation::morphMap([
+            'posts' => Post::class,
+            'comments' => Comment::class,
+        ]);
+    }
+}

--- a/app/Repositories/Application/AttachmentRepository.php
+++ b/app/Repositories/Application/AttachmentRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Repositories\Application;
+
+use App\Models\Attachment;
+use App\Repositories\Repository;
+use Illuminate\Database\Eloquent\Model;
+
+class AttachmentRepository extends Repository {
+
+	public $model = Attachment::class;
+
+	public $rulesStore = [
+        'attachmentable_type' => 'required|string',
+        'attachmentable_id' => 'required|integer',
+        'url' => 'required|url|max:255',
+    ];
+
+    public $rulesUpdate = [
+        'attachmentable_type' => 'required|string',
+        'attachmentable_id' => 'required|integer',
+        'url' => 'required|url|max:255',
+    ];
+
+    public function closureStoreModel($model, $request): Model
+    {
+    	return $model;
+    }
+
+    public function closureUpdateModel($model, $request, $id): Model
+    {
+    	return $model;
+    }
+
+    public function restrictionNotToDelete($request, $id)
+    {
+
+    }
+}

--- a/app/Repositories/Application/CommentAttachmentRepository.php
+++ b/app/Repositories/Application/CommentAttachmentRepository.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Repositories\Application;
+
+use App\Models\CommentAttachment;
+use App\Repositories\Repository;
+use Illuminate\Database\Eloquent\Model;
+
+class CommentAttachmentRepository extends Repository {
+
+	public $model = CommentAttachment::class;
+
+	public $rulesStore = [
+        'comment_id' => 'required|integer|exists:comments,id',
+        'url' => 'required|url|max:255',
+    ];
+
+    public $rulesUpdate = [
+        'comment_id' => 'required|integer|exists:comments,id',
+        'url' => 'required|url|max:255',
+    ];
+
+    public function closureStoreModel($model, $request): Model
+    {
+    	return $model;
+    }
+
+    public function closureUpdateModel($model, $request, $id): Model
+    {
+    	return $model;
+    }
+
+    public function restrictionNotToDelete($request, $id)
+    {
+
+    }
+}

--- a/app/Repositories/Application/PostAttachmentRepository.php
+++ b/app/Repositories/Application/PostAttachmentRepository.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Repositories\Application;
+
+use App\Models\PostAttachment;
+use App\Repositories\Repository;
+use Illuminate\Database\Eloquent\Model;
+
+class PostAttachmentRepository extends Repository {
+
+	public $model = PostAttachment::class;
+
+	public $rulesStore = [
+        'post_id' => 'required|integer|exists:posts,id',
+        'url' => 'required|url|max:255',
+    ];
+
+    public $rulesUpdate = [
+        'post_id' => 'required|integer|exists:posts,id',
+        'url' => 'required|url|max:255',
+    ];
+
+    public function closureStoreModel($model, $request): Model
+    {
+    	return $model;
+    }
+
+    public function closureUpdateModel($model, $request, $id): Model
+    {
+    	return $model;
+    }
+
+    public function restrictionNotToDelete($request, $id)
+    {
+
+    }
+}

--- a/app/Repositories/Application/UserRepository.php
+++ b/app/Repositories/Application/UserRepository.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Repositories\Application;
+
+use App\Models\User;
+use App\Repositories\Repository;
+use Illuminate\Database\Eloquent\Model;
+
+class UserRepository extends Repository {
+
+	public $model = User::class;
+
+	public $rulesStore = [
+        'name' => 'required',
+        'email' => 'required|email|unique',
+        'password' => 'required|string'
+    ];
+
+    public $rulesUpdate = [
+        'name' => 'required',
+        'email' => 'required|email|unique',
+        'password' => 'required|string'
+    ];
+
+    public function closureStoreModel($model, $request): Model
+    {
+    	return $model;
+    }
+
+    public function closureUpdateModel($model, $request, $id): Model
+    {
+    	return $model;
+    }
+
+    public function restrictionNotToDelete($request, $id)
+    {
+
+    }
+
+    public function getUsersWithPosts()
+    {
+        return $this->with('posts')->get();
+    }
+}

--- a/app/Repositories/Repository.php
+++ b/app/Repositories/Repository.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Repositories;
+
+use DB;
+use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\Model;
+
+abstract class Repository {
+
+	public $model;
+	public $rulesStore = [];
+	public $rulesUpdate = [];
+	public $rulesDestroy = [];
+	public $closureStoreModel;
+	protected $restrictionsNotToDelete = [];
+	public $restrictionsNotToDeleteMessage;
+
+	public function __construct()
+	{
+		$this->model = new $this->model;
+	}
+
+	abstract public function closureStoreModel($model, $request): Model;
+	abstract public function closureUpdateModel($model, $request, $id): Model;
+	abstract public function restrictionNotToDelete($request, $id);
+
+	protected function addRestrict(string $model, string $key, string $message, $closure = null)
+	{
+		$this->restrictionsNotToDelete[] = compact('model', 'key', 'message', 'closure');
+	}
+
+	public function canClearWithRestrictionsNotToDelete(Request $request, int $id)
+	{
+		foreach($this->restrictionsNotToDelete as $value)
+		{
+			$model = new $value['model'];
+			$query = $model->newQuery();
+			$query = $query->where($value['key'], $id);
+
+			if (! is_null($value['closure']))
+				$query = $value['closure']($query);
+
+			if ($query->count() > 0)
+			{
+				$this->restrictionsNotToDeleteMessage = $value['message'];
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	public function all()
+	{
+		return $this->model->all();
+	}
+
+	public function create(Request $request)
+	{
+		$this->request = $request;
+
+		return DB::transaction(function (){
+
+			$resource = new $this->model($this->request->all());
+			$resource = $this->closureStoreModel($resource, $this->request);
+			$resource->save();
+			$resource->fresh();
+
+			if (method_exists($this, 'callBackStoreModel'))
+				$this->callBackStoreModel($resource, $this->request);
+
+			return $resource;
+		});
+	}
+
+	public function update(Request $request, $id)
+	{
+		$this->id = $id;
+		$this->request = $request;
+
+		return DB::transaction(function (){
+
+			$resource = $this->model->find($this->id);
+			$resource->fill($this->request->all());
+			$resource = $this->closureUpdateModel($resource, $this->request, $this->id);
+			$resource->save();
+			$resource->fresh();
+
+			if (method_exists($this, 'callBackUpdateModel'))
+				$this->callBackUpdateModel($resource, $this->request);
+
+			return $resource;
+		});
+	}
+
+	public function find(Request $request, $id)
+	{
+		return $this->model->find($id);
+	}
+
+	public function delete(Request $request, $id)
+	{
+		$this->request = $request;
+		$this->id = $id;
+
+		return DB::transaction(function (){
+
+			$resource = $this->model->find($this->id);
+			$resource->delete();
+
+			if (method_exists($this, 'callBackDestroyModel'))
+					$this->callBackDestroyModel($resource, $this->request);
+
+			return $resource;
+		});
+	}
+
+	public function getRulesStore(Request $request)
+	{
+		return $this->rulesStore;
+	}
+
+	public function __call($method, $params)
+	{		
+		$query = $this->model->newQuery();
+
+		return call_user_func_array([$query, $method], $params);
+	}
+}

--- a/config/app.php
+++ b/config/app.php
@@ -175,6 +175,11 @@ return [
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
 
+        /*
+         * My Service Providers
+         */
+        App\Providers\PolymorphismProvider::class,
+
     ],
 
     /*

--- a/database/migrations/2021_09_07_020225_create_attachments_table.php
+++ b/database/migrations/2021_09_07_020225_create_attachments_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateAttachmentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('attachments', function (Blueprint $table) {
+            $table->id();
+            $table->string('url');
+            $table->morphs('attachmentable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('attachments');
+    }
+}

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -26,15 +26,13 @@
                         {{ $post->title }}
                     </td>
                     <td>
-                        {{ $post->post_attachments()->count() }}
+                        {{ $post->loadCount('post_attachments')->post_attachments_count }}
                     </td>
                     <td>
-                        {{ $post->comments()->count() }}
+                        {{ $post->loadCount('comments')->comments_count }}
                     </td>
                     <td>
-                        {{ $post->comments->reduce(function ($carry, $comment) {
-    return $carry + $comment->comment_attachments()->count();
-}) }}
+                        {{ $post->sumCommentsAttachmentCount() }}
                     </td>
                 </tr>
             @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\PostController;
 
 /*
 |--------------------------------------------------------------------------
@@ -17,8 +18,4 @@ Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('index', function () {
-    return view('index', [
-        'users' => \App\Models\User::all()
-    ]);
-});
+Route::get('index', [PostController::class, 'index']);


### PR DESCRIPTION
Ejercicios Terminados!

Nota: antes de mergear esta rama, es necesario estar posicionado en la rama "main" y asegurarse de correr los "seeders" con el comando "php artisan db:seed" (datos de prueba que se guardan en las tablas viejas post_attachments y comment_attachments).

Pasos para incluir los cambios de la rama:

Luego de instalar el proyecto en la rama "main" y correr los seeders debemos posicionarnos en la nueva rama "feature/dev-local".
Una vez posicionados en la rama "feature/dev-local" debemos correr las migraciones con el comando "php artisan migrate" para que se cree la nueva tabla polimorfica "attachments".
Luego ya podemos ejecutar el comando "php artisan migrate_attachments_data" para migrar toda la data de los attachments de posts y comments.
ejecutado el comando anterior podemos ingresar a la ruta "/index" desde el navegador para ver los resultados en pantalla y verificar los resultados de los queries y los modelos en la herramienta "barryvdh/laravel-debugbar".
Mejoras realizadas:

Las mejoras realizadas a la aplicación fueron aplicadas a las rutas, controladores y vistas, las cuales son:

La ruta "/index" del archivo web.php tenia una función anónima que llamaba directamente a la vista sin haber pasado por un controlador. Mejora realizada: modifiqué la ruta para que llamara el nuevo controlador PostController y al metodo "index" del mismo, para aislar totalmente la lógica de negocios del archivo de rutas "web.php".

Creé un controlador llamado PostController y un metodo con el nombre index para gestionar la lógica de negocios, consultas a la BD y llamar a la vista correspondiente.

Incluí un nueva capa de abstracción llamada "Repositories" para quitarle la responsabilidad al controlador de realizar consultas a la Base de Datos directamente en sus métodos, y a través de la inyección de dependencias incluir las clases de los repositorios para poder llamar los métodos de los mismos a través de las propiedades de la clase. Esta capa permite tener todas las consultas ordenadas en un mismo lugar (Clase), y se puede reutilizar la misma consulta en todo el proyecto, así evitando hacer la misma consulta en todos lados.

Agregué un método en el modelo Post llamado "sumCommentsAttachmentCount" que realiza un query para obtener la suma de todos los archivos adjuntos de los comentarios de un post, utilizando el Facade DB::raw para usar las funciones de agregación y no realizar una sobrecarga de queries a la BD directamente en la vista.

Los cambios en la vista index.blade.php fueron: En vez de utilizar llamados a las relaciones post_attachments de los post ($post->post_attachments->count()), use la función "loadCount" para no sobrecargar los modelos cargados en la consulta. Y en vez de recorrer todos los comentarios para sumar sus archivos adjuntos, solo llamo la función "sumCommentsAttachmentCount" del modelo Post que ya trae la suma de todos los archivos adjuntos de los comentarios de un post y poder mostrarlo en la vista sin sobrecargar los queries.

Comparación de Datos:

Antes (rama main):
- Queries: 656
- Models: 555
- Memory usage: 23MB
- Request duration: 4.15s

Después (rama feature/dev-local):
- Queries: 152
- Models: 155
- Memory usage: 20MB
- Request duration: 1.47s